### PR TITLE
Use TLS for source websites

### DIFF
--- a/pylicense.py
+++ b/pylicense.py
@@ -11,7 +11,7 @@ class PyLicense(object):
     from bs4 import BeautifulSoup
     import requests
 
-    page = requests.get("http://docs.continuum.io/anaconda/pkg-docs")
+    page = requests.get("https://docs.continuum.io/anaconda/pkg-docs")
     soup = BeautifulSoup(page.text)
     rows = soup.select("table.docutils tr")
     table = [row.select('td') for row in rows]
@@ -20,7 +20,7 @@ class PyLicense(object):
 
   def __init__(self, environment):
     self.environment = environment
-    self.client = xmlrpclib.ServerProxy('http://pypi.python.org/pypi')
+    self.client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
     if environment:
       self.conda_licenses = self.get_conda_licenses()
 


### PR DESCRIPTION
Fixes error with `xmlrpclib`

``` python
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/user/.virtualenvs/venv/lib/python2.7/site-packages/pylicense.py", line 139, in <module>
    output = [o for o in pylicense.process_stream(stream)]
  File "/Users/user/.virtualenvs/venv/lib/python2.7/site-packages/pylicense.py", line 125, in process_stream
    yield self.process_requirements_line(line)
  File "/Users/user/.virtualenvs/venv/lib/python2.7/site-packages/pylicense.py", line 118, in process_requirements_line
    return line.rstrip() + self._get_pip_license(line)
  File "/Users/user/.virtualenvs/venv/lib/python2.7/site-packages/pylicense.py", line 86, in _get_pip_license
    return self._get_dependency_license(line, '==', 2)
  File "/Users/user/.virtualenvs/venv/lib/python2.7/site-packages/pylicense.py", line 81, in _get_dependency_license
    license = self._get_license(package, version)
  File "/Users/user/.virtualenvs/venv/lib/python2.7/site-packages/pylicense.py", line 54, in _get_license
    info = self.client.release_data(package, version)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xmlrpclib.py", line 1240, in __call__
    return self.__send(self.__name, args)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xmlrpclib.py", line 1599, in __request
    verbose=self.__verbose
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xmlrpclib.py", line 1280, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xmlrpclib.py", line 1328, in single_request
    response.msg,
xmlrpclib.ProtocolError: <ProtocolError for pypi.python.org/pypi: 403 Must access using HTTPS instead of HTTP>
```
